### PR TITLE
fix: skip handling one_of for resolved resolution

### DIFF
--- a/lib/jet_ext/absinthe/one_of/middleware/input_modifier.ex
+++ b/lib/jet_ext/absinthe/one_of/middleware/input_modifier.ex
@@ -93,6 +93,8 @@ if Code.ensure_loaded?(Absinthe) do
       end
     end
 
+    def call(%Absinthe.Resolution{} = res, _opts), do: res
+
     # relay 风格的参数需要特殊处理一下，因为 relay 会提前对它进行特殊处理，
     # 把 %{input: arguments} 变成 arguments
     defp extract_argument_defs(%Absinthe.Resolution{


### PR DESCRIPTION
Resolution 可能已经 resolved 了，比如权限判定失败
