### PR TITLE
refactor: add condition for absinthe modules

### DIFF
--- a/lib/jet_ext/absinthe/node_builder.ex
+++ b/lib/jet_ext/absinthe/node_builder.ex
@@ -1,4 +1,4 @@
-if Code.ensure_loaded?(Absinthe) and Code.ensure_loaded?(Absinthe.Relay) do
+if Code.ensure_loaded?(Absinthe.Relay) do
   defmodule JetExt.Absinthe.NodeBuilder do
     @moduledoc false
 

--- a/lib/jet_ext/absinthe/notation_builder.ex
+++ b/lib/jet_ext/absinthe/notation_builder.ex
@@ -1,4 +1,4 @@
-if Code.ensure_loaded?(Absinthe) and Code.ensure_loaded?(Absinthe.Relay) do
+if Code.ensure_loaded?(Absinthe.Relay) do
   defmodule JetExt.Absinthe.NotationBuilder do
     @moduledoc false
 

--- a/lib/jet_ext/absinthe/one_of/one_of.ex
+++ b/lib/jet_ext/absinthe/one_of/one_of.ex
@@ -1,11 +1,13 @@
-defmodule JetExt.Absinthe.OneOf do
-  @moduledoc """
-  The homemade `one_of` directive for Absinthe.
+if Code.ensure_loaded?(Absinthe) do
+  defmodule JetExt.Absinthe.OneOf do
+    @moduledoc """
+    The homemade `one_of` directive for Absinthe.
 
-  ## 使用方法
-  1. 参考 `JetExt.Absinthe.OneOf.Phase` 的文档，将 phase 加入到 absinthe 的 phases 中
-  2. 参考 `JetExt.Absinthe.OneOf.SchemaProtoType` 的文档，在你的 absinthe schema 引入 `:one_of` directive
-  3. 参考 `JetExt.Absinthe.OneOf.Middleware.InputModifier` 的文档，用 `:one_of` 来定义你的 input_object
-  4. `JetExt.Absinthe.OneOf.Helpers` 目前提供了一个 `fold_key_to_field/3`，一个使用案例参考 3 中的例子
-  """
+    ## 使用方法
+    1. 参考 `JetExt.Absinthe.OneOf.Phase` 的文档，将 phase 加入到 absinthe 的 phases 中
+    2. 参考 `JetExt.Absinthe.OneOf.SchemaProtoType` 的文档，在你的 absinthe schema 引入 `:one_of` directive
+    3. 参考 `JetExt.Absinthe.OneOf.Middleware.InputModifier` 的文档，用 `:one_of` 来定义你的 input_object
+    4. `JetExt.Absinthe.OneOf.Helpers` 目前提供了一个 `fold_key_to_field/3`，一个使用案例参考 3 中的例子
+    """
+  end
 end

--- a/lib/jet_ext/absinthe/relay/connection.ex
+++ b/lib/jet_ext/absinthe/relay/connection.ex
@@ -1,233 +1,243 @@
-defmodule JetExt.Absinthe.Relay.Connection do
-  @moduledoc false
+if Code.ensure_loaded?(Absinthe.Relay) do
+  defmodule JetExt.Absinthe.Relay.Connection do
+    @moduledoc false
 
-  require Logger
+    require Logger
 
-  alias JetExt.Absinthe.Relay.Connection.Config
-  alias JetExt.Absinthe.Relay.Connection.Cursor
-  alias JetExt.Absinthe.Relay.Connection.Query
+    alias JetExt.Absinthe.Relay.Connection.Config
+    alias JetExt.Absinthe.Relay.Connection.Cursor
+    alias JetExt.Absinthe.Relay.Connection.Query
 
-  @doc """
-  Build a cursor_based connection from an Ecto Query
-  """
-  @spec from_query(
-          Ecto.Queryable.t(),
-          (Ecto.Queryable.t() -> [term()]),
-          map(),
-          Keyword.t()
-        ) :: {:ok, map()} | {:error, term()}
-  def from_query(query, repo_fun, args, opts \\ []) do
-    with {:ok, config} <- build_config(args, opts) do
-      config = %{
-        config
-        | cursor_fields: Keyword.fetch!(opts, :cursor_fields),
-          include_head_edge: Keyword.get(opts, :include_head_edge) || false,
-          include_tail_edge: Keyword.get(opts, :include_tail_edge) || false
-      }
+    @doc """
+    Build a cursor_based connection from an Ecto Query
+    """
+    @spec from_query(
+            Ecto.Queryable.t(),
+            (Ecto.Queryable.t() -> [term()]),
+            map(),
+            Keyword.t()
+          ) :: {:ok, map()} | {:error, term()}
+    def from_query(query, repo_fun, args, opts \\ []) do
+      with {:ok, config} <- build_config(args, opts) do
+        config = %{
+          config
+          | cursor_fields: Keyword.fetch!(opts, :cursor_fields),
+            include_head_edge: Keyword.get(opts, :include_head_edge) || false,
+            include_tail_edge: Keyword.get(opts, :include_tail_edge) || false
+        }
 
-      {
-        edges,
-        first,
-        last,
-        has_previous_page,
-        has_next_page
-      } =
-        query
-        |> Query.paginate(config)
-        |> repo_fun.()
-        |> build_cursors(config)
+        {
+          edges,
+          first,
+          last,
+          has_previous_page,
+          has_next_page
+        } =
+          query
+          |> Query.paginate(config)
+          |> repo_fun.()
+          |> build_cursors(config)
 
-      page_info = %{
-        start_cursor: first,
-        end_cursor: last,
-        has_previous_page:
-          has_page?(:previous, {query, repo_fun}, first, config, has_previous_page),
-        has_next_page: has_page?(:next, {query, repo_fun}, last, config, has_next_page)
-      }
+        page_info = %{
+          start_cursor: first,
+          end_cursor: last,
+          has_previous_page:
+            has_page?(:previous, {query, repo_fun}, first, config, has_previous_page),
+          has_next_page: has_page?(:next, {query, repo_fun}, last, config, has_next_page)
+        }
 
-      {:ok, %{edges: edges, page_info: page_info}}
-    end
-  end
-
-  defp build_config(%{first: first} = args, opts) do
-    do_build_config(:forward, first, args, opts)
-  end
-
-  defp build_config(%{last: last} = args, opts) do
-    do_build_config(:backward, last, args, opts)
-  end
-
-  defp build_config(_args, _opts), do: {:error, "You must either supply `:first` or `:last`"}
-
-  defp do_build_config(direction, limit, args, opts) do
-    with(
-      {:ok, before_cursor} <- Cursor.decode(args[:before]),
-      {:ok, after_cursor} <- Cursor.decode(args[:after])
-    ) do
-      {:ok,
-       Config.new(
-         direction: direction,
-         before: before_cursor,
-         after: after_cursor,
-         limit: limit,
-         maximum_limit: opts[:maximum_limit]
-       )}
-    end
-  end
-
-  # {edges, first, last, has_previous_page, has_next_page}
-  defp build_cursors([], _config), do: {[], nil, nil, false, false}
-
-  defp build_cursors([first | _] = sorted_entries, %Config{} = config) do
-    first = build_cursor(first, config)
-    do_build_cursors(sorted_entries, 0, {[], first, nil}, config)
-  end
-
-  # entries.count > limit
-  defp do_build_cursors(
-         [_ | _],
-         count,
-         {edges, first, last},
-         %Config{direction: :forward, limit: count} = config
-       ) do
-    {Enum.reverse(edges), first, last, not is_nil(config.after), true}
-  end
-
-  defp do_build_cursors(
-         [_ | _],
-         count,
-         {edges, first, last},
-         %Config{direction: :backward, limit: count} = config
-       ) do
-    {edges, last, first, true, not is_nil(config.before)}
-  end
-
-  # entries.count = limit
-  defp do_build_cursors(
-         [],
-         count,
-         {edges, first, last},
-         %Config{direction: :forward, limit: count} = config
-       ) do
-    {Enum.reverse(edges), first, last, not is_nil(config.after), not is_nil(config.before)}
-  end
-
-  defp do_build_cursors(
-         [],
-         count,
-         {edges, first, last},
-         %Config{direction: :backward, limit: count} = config
-       ) do
-    {edges, last, first, not is_nil(config.after), not is_nil(config.before)}
-  end
-
-  # entries.count < limit
-  defp do_build_cursors([], _count, {edges, first, last}, %Config{direction: :forward} = config) do
-    {Enum.reverse(edges), first, last, not is_nil(config.after), not is_nil(config.before)}
-  end
-
-  defp do_build_cursors([], _count, {edges, first, last}, %Config{direction: :backward} = config) do
-    {edges, last, first, not is_nil(config.after), not is_nil(config.before)}
-  end
-
-  defp do_build_cursors([item | rest], count, {edges, first, _last}, %Config{} = config) do
-    cursor = build_cursor(item, config)
-    edge = build_edge(item, cursor)
-
-    do_build_cursors(rest, count + 1, {[edge | edges], first, cursor}, config)
-  end
-
-  defp build_cursor({item, _args}, config) do
-    build_cursor(item, config)
-  end
-
-  defp build_cursor(item, config) do
-    Cursor.encode_record(item, config)
-  end
-
-  defp build_edge({item, args}, cursor) do
-    args
-    |> Enum.flat_map(fn
-      {key, _} when key in [:cursor, :node] ->
-        Logger.warning("Ignoring additional #{key} provided on edge (overriding is not allowed)")
-        []
-
-      {key, val} ->
-        [{key, val}]
-    end)
-    |> Enum.into(build_edge(item, cursor))
-  end
-
-  defp build_edge(item, cursor) do
-    %{
-      node: item,
-      cursor: cursor
-    }
-  end
-
-  defp has_page?(
-         :previous,
-         {query, repo_fun},
-         start_cursor,
-         %{include_head_edge: true, after: after_cursor} = config,
-         _default
-       )
-       when not is_nil(after_cursor) do
-    # credo:disable-for-previous-line Credo.Check.Refactor.NegatedIsNil
-    {:ok, cursor} =
-      if is_nil(start_cursor) do
-        {:ok, after_cursor}
-      else
-        Cursor.decode(start_cursor)
+        {:ok, %{edges: edges, page_info: page_info}}
       end
+    end
 
-    edges_exists?(query, repo_fun, %{
-      Config.disable_edge_including(config)
-      | before: cursor,
-        after: nil
-    })
-  end
+    defp build_config(%{first: first} = args, opts) do
+      do_build_config(:forward, first, args, opts)
+    end
 
-  defp has_page?(
-         :next,
-         {query, repo_fun},
-         end_cursor,
-         %{include_tail_edge: true, before: before_cursor} = config,
-         _default
-       )
-       when not is_nil(before_cursor) do
-    # credo:disable-for-previous-line Credo.Check.Refactor.NegatedIsNil
-    {:ok, cursor} =
-      if is_nil(end_cursor) do
-        {:ok, before_cursor}
-      else
-        Cursor.decode(end_cursor)
+    defp build_config(%{last: last} = args, opts) do
+      do_build_config(:backward, last, args, opts)
+    end
+
+    defp build_config(_args, _opts), do: {:error, "You must either supply `:first` or `:last`"}
+
+    defp do_build_config(direction, limit, args, opts) do
+      with(
+        {:ok, before_cursor} <- Cursor.decode(args[:before]),
+        {:ok, after_cursor} <- Cursor.decode(args[:after])
+      ) do
+        {:ok,
+         Config.new(
+           direction: direction,
+           before: before_cursor,
+           after: after_cursor,
+           limit: limit,
+           maximum_limit: opts[:maximum_limit]
+         )}
       end
+    end
 
-    edges_exists?(query, repo_fun, %{
-      Config.disable_edge_including(config)
-      | before: nil,
-        after: cursor
-    })
-  end
+    # {edges, first, last, has_previous_page, has_next_page}
+    defp build_cursors([], _config), do: {[], nil, nil, false, false}
 
-  defp has_page?(_side, {_query, _repo_fun}, _side_edge, _config, default), do: default
+    defp build_cursors([first | _] = sorted_entries, %Config{} = config) do
+      first = build_cursor(first, config)
+      do_build_cursors(sorted_entries, 0, {[], first, nil}, config)
+    end
 
-  defp edges_exists?(query, repo_fun, config) do
-    import Ecto.Query
+    # entries.count > limit
+    defp do_build_cursors(
+           [_ | _],
+           count,
+           {edges, first, last},
+           %Config{direction: :forward, limit: count} = config
+         ) do
+      {Enum.reverse(edges), first, last, not is_nil(config.after), true}
+    end
 
-    query
-    |> Query.paginate(config)
-    |> exclude(:select)
-    |> exclude(:preload)
-    |> exclude(:order_by)
-    |> exclude(:distinct)
-    |> select(1)
-    |> limit(1)
-    |> repo_fun.()
-    |> case do
-      [1] -> true
-      [] -> false
+    defp do_build_cursors(
+           [_ | _],
+           count,
+           {edges, first, last},
+           %Config{direction: :backward, limit: count} = config
+         ) do
+      {edges, last, first, true, not is_nil(config.before)}
+    end
+
+    # entries.count = limit
+    defp do_build_cursors(
+           [],
+           count,
+           {edges, first, last},
+           %Config{direction: :forward, limit: count} = config
+         ) do
+      {Enum.reverse(edges), first, last, not is_nil(config.after), not is_nil(config.before)}
+    end
+
+    defp do_build_cursors(
+           [],
+           count,
+           {edges, first, last},
+           %Config{direction: :backward, limit: count} = config
+         ) do
+      {edges, last, first, not is_nil(config.after), not is_nil(config.before)}
+    end
+
+    # entries.count < limit
+    defp do_build_cursors([], _count, {edges, first, last}, %Config{direction: :forward} = config) do
+      {Enum.reverse(edges), first, last, not is_nil(config.after), not is_nil(config.before)}
+    end
+
+    defp do_build_cursors(
+           [],
+           _count,
+           {edges, first, last},
+           %Config{direction: :backward} = config
+         ) do
+      {edges, last, first, not is_nil(config.after), not is_nil(config.before)}
+    end
+
+    defp do_build_cursors([item | rest], count, {edges, first, _last}, %Config{} = config) do
+      cursor = build_cursor(item, config)
+      edge = build_edge(item, cursor)
+
+      do_build_cursors(rest, count + 1, {[edge | edges], first, cursor}, config)
+    end
+
+    defp build_cursor({item, _args}, config) do
+      build_cursor(item, config)
+    end
+
+    defp build_cursor(item, config) do
+      Cursor.encode_record(item, config)
+    end
+
+    defp build_edge({item, args}, cursor) do
+      args
+      |> Enum.flat_map(fn
+        {key, _} when key in [:cursor, :node] ->
+          Logger.warning(
+            "Ignoring additional #{key} provided on edge (overriding is not allowed)"
+          )
+
+          []
+
+        {key, val} ->
+          [{key, val}]
+      end)
+      |> Enum.into(build_edge(item, cursor))
+    end
+
+    defp build_edge(item, cursor) do
+      %{
+        node: item,
+        cursor: cursor
+      }
+    end
+
+    defp has_page?(
+           :previous,
+           {query, repo_fun},
+           start_cursor,
+           %{include_head_edge: true, after: after_cursor} = config,
+           _default
+         )
+         when not is_nil(after_cursor) do
+      # credo:disable-for-previous-line Credo.Check.Refactor.NegatedIsNil
+      {:ok, cursor} =
+        if is_nil(start_cursor) do
+          {:ok, after_cursor}
+        else
+          Cursor.decode(start_cursor)
+        end
+
+      edges_exists?(query, repo_fun, %{
+        Config.disable_edge_including(config)
+        | before: cursor,
+          after: nil
+      })
+    end
+
+    defp has_page?(
+           :next,
+           {query, repo_fun},
+           end_cursor,
+           %{include_tail_edge: true, before: before_cursor} = config,
+           _default
+         )
+         when not is_nil(before_cursor) do
+      # credo:disable-for-previous-line Credo.Check.Refactor.NegatedIsNil
+      {:ok, cursor} =
+        if is_nil(end_cursor) do
+          {:ok, before_cursor}
+        else
+          Cursor.decode(end_cursor)
+        end
+
+      edges_exists?(query, repo_fun, %{
+        Config.disable_edge_including(config)
+        | before: nil,
+          after: cursor
+      })
+    end
+
+    defp has_page?(_side, {_query, _repo_fun}, _side_edge, _config, default), do: default
+
+    defp edges_exists?(query, repo_fun, config) do
+      import Ecto.Query
+
+      query
+      |> Query.paginate(config)
+      |> exclude(:select)
+      |> exclude(:preload)
+      |> exclude(:order_by)
+      |> exclude(:distinct)
+      |> select(1)
+      |> limit(1)
+      |> repo_fun.()
+      |> case do
+        [1] -> true
+        [] -> false
+      end
     end
   end
 end

--- a/lib/jet_ext/absinthe/relay/connection/config.ex
+++ b/lib/jet_ext/absinthe/relay/connection/config.ex
@@ -1,37 +1,39 @@
-defmodule JetExt.Absinthe.Relay.Connection.Config do
-  @moduledoc false
+if Code.ensure_loaded?(Absinthe.Relay) do
+  defmodule JetExt.Absinthe.Relay.Connection.Config do
+    @moduledoc false
 
-  @type t :: %__MODULE__{}
+    @type t :: %__MODULE__{}
 
-  defstruct [
-    :direction,
-    :after,
-    :before,
-    :limit,
-    cursor_fields: [],
-    # include head and tail
-    include_head_edge: false,
-    include_tail_edge: false
-  ]
+    defstruct [
+      :direction,
+      :after,
+      :before,
+      :limit,
+      cursor_fields: [],
+      # include head and tail
+      include_head_edge: false,
+      include_tail_edge: false
+    ]
 
-  @default_limit 50
-  @minimum_limit 1
-  @maximum_limit 500
+    @default_limit 50
+    @minimum_limit 1
+    @maximum_limit 500
 
-  @spec new(keyword()) :: t()
-  def new(opts \\ []) do
-    struct(__MODULE__, Keyword.put(opts, :limit, limit(opts)))
-  end
+    @spec new(keyword()) :: t()
+    def new(opts \\ []) do
+      struct(__MODULE__, Keyword.put(opts, :limit, limit(opts)))
+    end
 
-  defp limit(opts) do
-    min(
-      max(opts[:limit] || @default_limit, @minimum_limit),
-      opts[:maximum_limit] || @maximum_limit
-    )
-  end
+    defp limit(opts) do
+      min(
+        max(opts[:limit] || @default_limit, @minimum_limit),
+        opts[:maximum_limit] || @maximum_limit
+      )
+    end
 
-  @spec disable_edge_including(t()) :: t()
-  def disable_edge_including(%__MODULE__{} = config) do
-    %{config | include_head_edge: false, include_tail_edge: false}
+    @spec disable_edge_including(t()) :: t()
+    def disable_edge_including(%__MODULE__{} = config) do
+      %{config | include_head_edge: false, include_tail_edge: false}
+    end
   end
 end

--- a/lib/jet_ext/absinthe/relay/connection/cursor.ex
+++ b/lib/jet_ext/absinthe/relay/connection/cursor.ex
@@ -1,30 +1,32 @@
-defmodule JetExt.Absinthe.Relay.Connection.Cursor do
-  @moduledoc false
+if Code.ensure_loaded?(Absinthe.Relay) do
+  defmodule JetExt.Absinthe.Relay.Connection.Cursor do
+    @moduledoc false
 
-  alias JetExt.Absinthe.Relay.Connection.Config
-  alias JetExt.Absinthe.Relay.Connection.Cursor.Extractor
+    alias JetExt.Absinthe.Relay.Connection.Config
+    alias JetExt.Absinthe.Relay.Connection.Cursor.Extractor
 
-  @spec decode(binary()) :: {:ok, term()} | {:error, term()}
-  def decode(nil), do: {:ok, nil}
+    @spec decode(binary()) :: {:ok, term()} | {:error, term()}
+    def decode(nil), do: {:ok, nil}
 
-  def decode(encoded_cursor) do
-    encoded_cursor
-    |> Base.url_decode64!(padding: false)
-    |> :erlang.binary_to_term([:safe])
-  rescue
-    ArgumentError ->
-      {:error, "`#{encoded_cursor}` does not appear to be a valid cursor."}
-  else
-    cursor ->
-      {:ok, cursor}
-  end
+    def decode(encoded_cursor) do
+      encoded_cursor
+      |> Base.url_decode64!(padding: false)
+      |> :erlang.binary_to_term([:safe])
+    rescue
+      ArgumentError ->
+        {:error, "`#{encoded_cursor}` does not appear to be a valid cursor."}
+    else
+      cursor ->
+        {:ok, cursor}
+    end
 
-  # schemaless_row is a map not a struct
-  @spec encode_record(map(), Config.t()) :: binary()
-  def encode_record(%{} = map, %Config{} = config) do
-    map
-    |> Extractor.extract(Keyword.keys(config.cursor_fields))
-    |> :erlang.term_to_binary()
-    |> Base.url_encode64(padding: false)
+    # schemaless_row is a map not a struct
+    @spec encode_record(map(), Config.t()) :: binary()
+    def encode_record(%{} = map, %Config{} = config) do
+      map
+      |> Extractor.extract(Keyword.keys(config.cursor_fields))
+      |> :erlang.term_to_binary()
+      |> Base.url_encode64(padding: false)
+    end
   end
 end

--- a/lib/jet_ext/absinthe/relay/connection/cursor/extractor.ex
+++ b/lib/jet_ext/absinthe/relay/connection/cursor/extractor.ex
@@ -1,28 +1,30 @@
-defprotocol JetExt.Absinthe.Relay.Connection.Cursor.Extractor do
-  @moduledoc false
+if Code.ensure_loaded?(Absinthe.Relay) do
+  defprotocol JetExt.Absinthe.Relay.Connection.Cursor.Extractor do
+    @moduledoc false
 
-  @spec extract(t(), cursor_fields :: [atom()]) :: map()
-  def extract(data, cursor_fields)
-end
-
-defimpl JetExt.Absinthe.Relay.Connection.Cursor.Extractor, for: Map do
-  def extract(data, cursor_fields) do
-    Map.take(data, cursor_fields)
+    @spec extract(t(), cursor_fields :: [atom()]) :: map()
+    def extract(data, cursor_fields)
   end
-end
 
-defimpl JetExt.Absinthe.Relay.Connection.Cursor.Extractor, for: Any do
-  defmacro __deriving__(module, _struct, _opts) do
-    quote do
-      defimpl JetExt.Absinthe.Relay.Connection.Cursor.Extractor, for: unquote(module) do
-        def extract(data, cursor_fields) do
-          Map.take(data, cursor_fields)
-        end
-      end
+  defimpl JetExt.Absinthe.Relay.Connection.Cursor.Extractor, for: Map do
+    def extract(data, cursor_fields) do
+      Map.take(data, cursor_fields)
     end
   end
 
-  def extract(_data, _cursor_fields) do
-    raise "Not implemented"
+  defimpl JetExt.Absinthe.Relay.Connection.Cursor.Extractor, for: Any do
+    defmacro __deriving__(module, _struct, _opts) do
+      quote do
+        defimpl JetExt.Absinthe.Relay.Connection.Cursor.Extractor, for: unquote(module) do
+          def extract(data, cursor_fields) do
+            Map.take(data, cursor_fields)
+          end
+        end
+      end
+    end
+
+    def extract(_data, _cursor_fields) do
+      raise "Not implemented"
+    end
   end
 end

--- a/lib/jet_ext/absinthe/relay/connection/field_type.ex
+++ b/lib/jet_ext/absinthe/relay/connection/field_type.ex
@@ -1,37 +1,39 @@
-defprotocol JetExt.Absinthe.Relay.Connection.FieldType do
-  @doc "Get the field type for a field of a queryable."
-  @spec get_type(t(), atom()) :: Ecto.Type.t()
-  def get_type(queryable, field)
-end
-
-defimpl JetExt.Absinthe.Relay.Connection.FieldType, for: Ecto.Query do
-  def get_type(%{from: %Ecto.Query.FromExpr{source: {_source, nil}}} = query, _field) do
-    raise "Schemaless queries are not supported, query: #{inspect(query)}"
+if Code.ensure_loaded?(Absinthe.Relay) do
+  defprotocol JetExt.Absinthe.Relay.Connection.FieldType do
+    @doc "Get the field type for a field of a queryable."
+    @spec get_type(t(), atom()) :: Ecto.Type.t()
+    def get_type(queryable, field)
   end
 
-  def get_type(%{from: %Ecto.Query.FromExpr{source: {_source, schema}}} = query, field) do
-    type = schema.__schema__(:type, field)
-
-    if is_nil(type) do
-      raise "Field #{inspect(field)} not found in schema #{inspect(schema)}, query: #{inspect(query)}"
-    else
-      type
+  defimpl JetExt.Absinthe.Relay.Connection.FieldType, for: Ecto.Query do
+    def get_type(%{from: %Ecto.Query.FromExpr{source: {_source, nil}}} = query, _field) do
+      raise "Schemaless queries are not supported, query: #{inspect(query)}"
     end
-  end
-end
 
-defimpl JetExt.Absinthe.Relay.Connection.FieldType, for: Atom do
-  def get_type(schema, field) do
-    if function_exported?(schema, :__schema__, 2) do
+    def get_type(%{from: %Ecto.Query.FromExpr{source: {_source, schema}}} = query, field) do
       type = schema.__schema__(:type, field)
 
       if is_nil(type) do
-        raise "Field #{inspect(field)} not found in schema #{inspect(schema)}"
+        raise "Field #{inspect(field)} not found in schema #{inspect(schema)}, query: #{inspect(query)}"
       else
         type
       end
-    else
-      raise "The schema #{inspect(schema)} is not an Ecto schema."
+    end
+  end
+
+  defimpl JetExt.Absinthe.Relay.Connection.FieldType, for: Atom do
+    def get_type(schema, field) do
+      if function_exported?(schema, :__schema__, 2) do
+        type = schema.__schema__(:type, field)
+
+        if is_nil(type) do
+          raise "Field #{inspect(field)} not found in schema #{inspect(schema)}"
+        else
+          type
+        end
+      else
+        raise "The schema #{inspect(schema)} is not an Ecto schema."
+      end
     end
   end
 end

--- a/lib/jet_ext/absinthe/relay/node/notation.ex
+++ b/lib/jet_ext/absinthe/relay/node/notation.ex
@@ -1,4 +1,4 @@
-if Code.ensure_loaded?(Absinthe) do
+if Code.ensure_loaded?(Absinthe.Relay) do
   defmodule JetExt.Absinthe.Relay.Node.Notation do
     @moduledoc """
     Macros used to define Node-related schema entities

--- a/lib/jet_ext/absinthe/relay/schema.ex
+++ b/lib/jet_ext/absinthe/relay/schema.ex
@@ -1,4 +1,4 @@
-if Code.ensure_loaded?(Absinthe) and Code.ensure_loaded?(Absinthe.Relay) do
+if Code.ensure_loaded?(Absinthe.Relay) do
   defmodule JetExt.Absinthe.Relay.Schema do
     @moduledoc """
     Used to extend a schema with Relay-specific macros and types.


### PR DESCRIPTION
fix complie warning for projects that don't use absinthe_relay

```elixir
==> jet_ext
Compiling 39 files (.ex)
warning: Absinthe.Relay.Node.from_global_id/2 is undefined (module Absinthe.Relay.Node is not available or is yet to be defined)
Warning:   lib/jet_ext/absinthe/relay/node/notation.ex:144: JetExt.Absinthe.Relay.Node.Notation.resolve_with_global_id/2
```
