### PR TITLE
refactor: export Absinthe Relay related protocols

### DIFF
--- a/lib/jet_ext/absinthe/relay/connection/cursor/extractor.ex
+++ b/lib/jet_ext/absinthe/relay/connection/cursor/extractor.ex
@@ -1,30 +1,28 @@
-if Code.ensure_loaded?(Absinthe.Relay) do
-  defprotocol JetExt.Absinthe.Relay.Connection.Cursor.Extractor do
-    @moduledoc false
+defprotocol JetExt.Absinthe.Relay.Connection.Cursor.Extractor do
+  @moduledoc false
 
-    @spec extract(t(), cursor_fields :: [atom()]) :: map()
-    def extract(data, cursor_fields)
+  @spec extract(t(), cursor_fields :: [atom()]) :: map()
+  def extract(data, cursor_fields)
+end
+
+defimpl JetExt.Absinthe.Relay.Connection.Cursor.Extractor, for: Map do
+  def extract(data, cursor_fields) do
+    Map.take(data, cursor_fields)
   end
+end
 
-  defimpl JetExt.Absinthe.Relay.Connection.Cursor.Extractor, for: Map do
-    def extract(data, cursor_fields) do
-      Map.take(data, cursor_fields)
-    end
-  end
-
-  defimpl JetExt.Absinthe.Relay.Connection.Cursor.Extractor, for: Any do
-    defmacro __deriving__(module, _struct, _opts) do
-      quote do
-        defimpl JetExt.Absinthe.Relay.Connection.Cursor.Extractor, for: unquote(module) do
-          def extract(data, cursor_fields) do
-            Map.take(data, cursor_fields)
-          end
+defimpl JetExt.Absinthe.Relay.Connection.Cursor.Extractor, for: Any do
+  defmacro __deriving__(module, _struct, _opts) do
+    quote do
+      defimpl JetExt.Absinthe.Relay.Connection.Cursor.Extractor, for: unquote(module) do
+        def extract(data, cursor_fields) do
+          Map.take(data, cursor_fields)
         end
       end
     end
+  end
 
-    def extract(_data, _cursor_fields) do
-      raise "Not implemented"
-    end
+  def extract(_data, _cursor_fields) do
+    raise "Not implemented"
   end
 end

--- a/lib/jet_ext/absinthe/relay/connection/field_type.ex
+++ b/lib/jet_ext/absinthe/relay/connection/field_type.ex
@@ -1,39 +1,37 @@
-if Code.ensure_loaded?(Absinthe.Relay) do
-  defprotocol JetExt.Absinthe.Relay.Connection.FieldType do
-    @doc "Get the field type for a field of a queryable."
-    @spec get_type(t(), atom()) :: Ecto.Type.t()
-    def get_type(queryable, field)
+defprotocol JetExt.Absinthe.Relay.Connection.FieldType do
+  @doc "Get the field type for a field of a queryable."
+  @spec get_type(t(), atom()) :: Ecto.Type.t()
+  def get_type(queryable, field)
+end
+
+defimpl JetExt.Absinthe.Relay.Connection.FieldType, for: Ecto.Query do
+  def get_type(%{from: %Ecto.Query.FromExpr{source: {_source, nil}}} = query, _field) do
+    raise "Schemaless queries are not supported, query: #{inspect(query)}"
   end
 
-  defimpl JetExt.Absinthe.Relay.Connection.FieldType, for: Ecto.Query do
-    def get_type(%{from: %Ecto.Query.FromExpr{source: {_source, nil}}} = query, _field) do
-      raise "Schemaless queries are not supported, query: #{inspect(query)}"
-    end
+  def get_type(%{from: %Ecto.Query.FromExpr{source: {_source, schema}}} = query, field) do
+    type = schema.__schema__(:type, field)
 
-    def get_type(%{from: %Ecto.Query.FromExpr{source: {_source, schema}}} = query, field) do
+    if is_nil(type) do
+      raise "Field #{inspect(field)} not found in schema #{inspect(schema)}, query: #{inspect(query)}"
+    else
+      type
+    end
+  end
+end
+
+defimpl JetExt.Absinthe.Relay.Connection.FieldType, for: Atom do
+  def get_type(schema, field) do
+    if function_exported?(schema, :__schema__, 2) do
       type = schema.__schema__(:type, field)
 
       if is_nil(type) do
-        raise "Field #{inspect(field)} not found in schema #{inspect(schema)}, query: #{inspect(query)}"
+        raise "Field #{inspect(field)} not found in schema #{inspect(schema)}"
       else
         type
       end
-    end
-  end
-
-  defimpl JetExt.Absinthe.Relay.Connection.FieldType, for: Atom do
-    def get_type(schema, field) do
-      if function_exported?(schema, :__schema__, 2) do
-        type = schema.__schema__(:type, field)
-
-        if is_nil(type) do
-          raise "Field #{inspect(field)} not found in schema #{inspect(schema)}"
-        else
-          type
-        end
-      else
-        raise "The schema #{inspect(schema)} is not an Ecto schema."
-      end
+    else
+      raise "The schema #{inspect(schema)} is not an Ecto schema."
     end
   end
 end


### PR DESCRIPTION
These protocols might be in an app that doesn't depend on Absinthe Relay,
but its web app depends on it.
